### PR TITLE
Bundle Qt and dependencies inside AppImage correctly

### DIFF
--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
     - name: Checkout
@@ -20,9 +20,8 @@ jobs:
   
     - name: Set up GNAT toolchain
       run: >
-        sudo apt-get update && 
-        sudo apt-get install gnat gprbuild make "libqt5*5" libpulse-dev
-
+        sudo apt-get update &&
+        sudo apt-get install gnat gprbuild make qt5-default qt5-qmake qtbase5-dev-tools qt3d5-dev "qt5-*plugins" "qt3d-*-plugin" "libqt5*5" "libqt5*5-plugins" libspeechd2 libpulse-dev
 
     - name: Build
       run: make

--- a/AppRun
+++ b/AppRun
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $APPDIR/linux/qt-5.15x86-64/usr/local/Qt-5.15.0/lib
+exec $APPDIR/usr/bin/covidsim $@

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 QT_VERSION = 5.15
 
-QT_LIB_DIR = linux/qt-$(QT_VERSION)x86-64/usr/local/Qt-$(QT_VERSION).0/lib
+QT_BASE_DIR= linux/qt-$(QT_VERSION)x86-64/usr/local/Qt-$(QT_VERSION).0/
+
+QT5_ADA_DIR = linux/qt5adax86-64/qt5adax86-64
 
 all: | linux/qt5adax86-64 linux/qt-$(QT_VERSION)x86-64
 	gprbuild -p covidsim.gpr
@@ -16,8 +18,8 @@ linux/qt-$(QT_VERSION)x86-64:
 	tar -C linux -xf qt$(QT_VERSION)x86-64.tar.bz2
 
 run:
-	cd $(QT_LIB_DIR) ; \
-    LD_LIBRARY_PATH=".:$(PWD)/linux/qt5adax86-64/qt5adax86-64/usr/local/lib" ./covidsim
+	cd $(QT_BASE_DIR)/lib ; \
+    LD_LIBRARY_PATH=".:$(PWD)/$(QT5_ADA_DIR)/usr/local/lib" ./covidsim
 
 clean:
 	gprclean covidsim.gpr
@@ -25,15 +27,19 @@ clean:
 
 AppImage:
 	mkdir -p AppDir/src/form AppDir/deps/xph_covid19/data
-	rsync -a distri/* AppDir
-	rsync -a linux AppDir
+	rsync -a distri/* linux AppDir
 	rsync -a src/form/*.ui AppDir/src/form
 	rsync -a deps/xph_covid19/data/*.csv AppDir/deps/xph_covid19/data 
 	wget -nv -c https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-	chmod +x linuxdeploy-x86_64.AppImage
-	LD_LIBRARY_PATH="$(QT_LIB_DIR):linux/qt5adax86-64/qt5adax86-64/usr/local/lib" \
+	wget -nv -c https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+	chmod +x linuxdeploy-*.AppImage
+	VERSION=continuous \
+	QTDIR=$(QT_BASE_DIR) \
+	PATH=$(QT_BASE_DIR)/bin:$$PATH \
+	PKG_CONFIG_PATH=$(QT_BASE_DIR)/lib/pkgconfig:$$PKG_CONFIG_PATH \
+	LD_LIBRARY_PATH="$(QT_BASE_DIR)/lib:$(QT5_ADA_DIR)/usr/local/lib:$$LD_LIBRARY_PATH" \
       ./linuxdeploy-x86_64.AppImage \
-      --executable AppDir/$(QT_LIB_DIR)/covidsim \
+      --executable AppDir/$(QT_BASE_DIR)/lib/covidsim \
       --desktop-file distri/covidsim.desktop --icon-file=distri/covidsim.png \
-      --library linux/qt5adax86-64/qt5adax86-64/usr/local/lib/libqt5c.so \
-      --appdir AppDir --output appimage
+      --library $(QT5_ADA_DIR)/usr/local/lib/libqt5c.so \
+      --custom-apprun=AppRun --appdir AppDir --plugin qt --output appimage


### PR DESCRIPTION
Use Ubuntu Xenial Qt-5.15 repository and linuxdeploy-plugin-qt for the
action that builds the AppImage.

See issue #12